### PR TITLE
adjustments for AppAPI + fixed typos

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,76 +2,59 @@
 
 .PHONY: help
 help:
-	@echo "Welcome to TalkBot example. Please use \`make <target>\` where <target> is one of"
+	@echo "Welcome to SummarAI bot. Please use \`make <target>\` where <target> is one of"
 	@echo " "
 	@echo "  Next commands are only for dev environment with nextcloud-docker-dev!"
 	@echo "  They should run from the host you are developing on(with activated venv) and not in the container with Nextcloud!"
 	@echo "  "
 	@echo "  build-push        build image and upload to ghcr.io"
 	@echo "  "
-	@echo "  deploy            deploy example to registered 'docker_dev' for Nextcloud Last"
-	@echo "  deploy27          deploy example to registered 'docker_dev' for Nextcloud 27"
-	@echo "  "
-	@echo "  run               install TalkBot for Nextcloud Last"
-	@echo "  run27             install TalkBot for Nextcloud 27"
+	@echo "  run               install SummarAI for Nextcloud Last"
+	@echo "  run27             install SummarAI for Nextcloud 27"
 	@echo "  "
 	@echo "  For development of this example use PyCharm run configurations. Development is always set for last Nextcloud."
-	@echo "  First run 'TalkBot' and then 'make registerXX', after that you can use/debug/develop it and easy test."
+	@echo "  First run 'SummarAI' and then 'make registerXX', after that you can use/debug/develop it and easy test."
 	@echo "  "
-	@echo "  register          perform registration of running 'TalkBot' into the 'manual_install' deploy daemon."
-	@echo "  register_local    perform registration of running 'TalkBot' into the 'manual_install' deploy daemon for a local running instance."
-	@echo "  register27        perform registration of running 'TalkBot' into the 'manual_install' deploy daemon."
+	@echo "  register          perform registration of running 'SummarAI' into the 'manual_install' deploy daemon."
+	@echo "  register_local    perform registration of running 'SummarAI' into the 'manual_install' deploy daemon for a local running instance."
+	@echo "  register27        perform registration of running 'SummarAI' into the 'manual_install' deploy daemon."
 
 .PHONY: build-push
 build-push:
 	docker login ghcr.io
 	docker buildx build --push --platform linux/arm64/v8,linux/amd64 --tag ghcr.io/nextcloud/summarai:1.0.0 .
 
-.PHONY: deploy
-deploy:
-	docker exec master-nextcloud-1 sudo -u www-data php occ app_api:app:unregister summarai --silent || true
-	docker exec master-nextcloud-1 sudo -u www-data php occ app_api:app:register summarai docker_dev --json-info \
-  "{\"appid\":\"summarai\",\"name\":\"SummarAI\",\"daemon_config_name\":\"docker_dev\",\"version\":\"1.0.0\",\"secret\":\"12345\",\"port\":9031,\"scopes\":[\"AI_PROVIDERS\", \"NOTIFICATIONS\", \"TALK\", \"TALK_BOT\", \"USER_INFO\", \"SYSTEM\", \"ALL\"],\"system_app\":1}" \
-  --force-scopes --wait-finish
-
-.PHONY: deploy27
-deploy27:
-	docker exec master-stable27-1 sudo -u www-data php occ app_api:app:unregister summarai --silent || true
-	docker exec master-stable27-1 sudo -u www-data php occ app_api:app:register summarai docker_dev --json-info \
-  "{\"appid\":\"summarai\",\"name\":\"SummarAI\",\"daemon_config_name\":\"docker_dev\",\"version\":\"1.0.0\",\"secret\":\"12345\",\"port\":9031,\"scopes\":[\"AI_PROVIDERS\", \"NOTIFICATIONS\", \"TALK\", \"TALK_BOT\", \"USER_INFO\", \"SYSTEM\", \"ALL\"],\"system_app\":1}" \
-  --force-scopes --wait-finish
-
 .PHONY: run
 run:
 	docker exec master-nextcloud-1 sudo -u www-data php occ app_api:app:unregister summarai --silent || true
 	docker exec master-nextcloud-1 sudo -u www-data php occ app_api:app:register summarai docker_dev --json-info \
-  "{\"appid\":\"summarai\",\"name\":\"SummarAI\",\"daemon_config_name\":\"docker_dev\",\"version\":\"1.0.0\",\"secret\":\"12345\",\"port\":9031,\"scopes\":[\"AI_PROVIDERS\", \"NOTIFICATIONS\", \"TALK\", \"TALK_BOT\", \"USER_INFO\", \"SYSTEM\", \"ALL\"],\"system_app\":1}" \
+  "{\"id\":\"summarai\",\"name\":\"SummarAI\",\"daemon_config_name\":\"docker_dev\",\"version\":\"1.0.0\",\"secret\":\"12345\",\"port\":9031,\"scopes\":[\"AI_PROVIDERS\", \"NOTIFICATIONS\", \"TALK\", \"TALK_BOT\", \"USER_INFO\", \"SYSTEM\", \"TEXT_PROCESSING\"],\"system\":1}" \
   --force-scopes --wait-finish
 
 .PHONY: run27
 run27:
 	docker exec master-stable27-1 sudo -u www-data php occ app_api:app:unregister summarai --silent || true
 	docker exec master-stable27-1 sudo -u www-data php occ app_api:app:register summarai manual_install --json-info \
-  "{\"appid\":\"summarai\",\"name\":\"SummarAI\",\"daemon_config_name\":\"docker_dev\",\"version\":\"1.0.0\",\"secret\":\"12345\",\"port\":9031,\"scopes\":[\"AI_PROVIDERS\", \"NOTIFICATIONS\", \"TALK\", \"TALK_BOT\", \"USER_INFO\", \"SYSTEM\", \"ALL\"],\"system_app\":1}" \
+  "{\"id\":\"summarai\",\"name\":\"SummarAI\",\"daemon_config_name\":\"docker_dev\",\"version\":\"1.0.0\",\"secret\":\"12345\",\"port\":9031,\"scopes\":[\"AI_PROVIDERS\", \"NOTIFICATIONS\", \"TALK\", \"TALK_BOT\", \"USER_INFO\", \"SYSTEM\", \"TEXT_PROCESSING\"],\"system\":1}" \
   --force-scopes --wait-finish
 
 .PHONY: register
 register:
 	docker exec master-nextcloud-1 sudo -u www-data php occ app_api:app:unregister summarai --silent || true
 	docker exec master-nextcloud-1 sudo -u www-data php occ app_api:app:register summarai manual_install --json-info \
-  "{\"appid\":\"summarai\",\"name\":\"SummarAI\",\"daemon_config_name\":\"manual_install\",\"version\":\"1.0.0\",\"secret\":\"12345\",\"port\":9031,\"scopes\":[\"AI_PROVIDERS\", \"NOTIFICATIONS\", \"TALK\", \"TALK_BOT\", \"USER_INFO\", \"SYSTEM\", \"ALL\"],\"system_app\":1}" \
+  "{\"id\":\"summarai\",\"name\":\"SummarAI\",\"daemon_config_name\":\"manual_install\",\"version\":\"1.0.0\",\"secret\":\"12345\",\"port\":9031,\"scopes\":[\"AI_PROVIDERS\", \"NOTIFICATIONS\", \"TALK\", \"TALK_BOT\", \"USER_INFO\", \"SYSTEM\", \"TEXT_PROCESSING\"],\"system\":1}" \
   --force-scopes --wait-finish
 
 .PHONY: register_local
 register_local:
 	sudo -u www-data php /var/www/nc_29/occ app_api:app:unregister summarai --silent || true
 	sudo -u www-data php /var/www/nc_29/occ app_api:app:register summarai manual_install --json-info \
-  "{\"appid\":\"summarai\",\"name\":\"SummarAI\",\"daemon_config_name\":\"manual_install\",\"version\":\"1.0.0\",\"secret\":\"12345\",\"host\":\"192.168.0.199\",\"port\":9031,\"scopes\":[\"AI_PROVIDERS\", \"NOTIFICATIONS\", \"TALK\", \"TALK_BOT\", \"ALL\"],\"protocol\":\"http\",\"system_app\":1}" \
+  "{\"id\":\"summarai\",\"name\":\"SummarAI\",\"daemon_config_name\":\"manual_install\",\"version\":\"1.0.0\",\"secret\":\"12345\",\"host\":\"192.168.0.199\",\"port\":9031,\"scopes\":[\"AI_PROVIDERS\", \"NOTIFICATIONS\", \"TALK\", \"TALK_BOT\", \"TEXT_PROCESSING\"],\"protocol\":\"http\",\"system\":1}" \
   --force-scopes --wait-finish
 
 .PHONY: register27
 register27:
 	docker exec master-stable27-1 sudo -u www-data php occ app_api:app:unregister summarai --silent || true
 	docker exec master-stable27-1 sudo -u www-data php occ app_api:app:register summarai manual_install --json-info \
-  "{\"appid\":\"summarai\",\"name\":\"SummarAI\",\"daemon_config_name\":\"manual_install\",\"version\":\"1.0.0\",\"secret\":\"12345\",\"port\":9031,\"scopes\":[\"AI_PROVIDERS\", \"NOTIFICATIONS\", \"TALK\", \"TALK_BOT\", \"USER_INFO\", \"SYSTEM\", \"ALL\"],\"system_app\":1}" \
+  "{\"id\":\"summarai\",\"name\":\"SummarAI\",\"daemon_config_name\":\"manual_install\",\"version\":\"1.0.0\",\"secret\":\"12345\",\"port\":9031,\"scopes\":[\"AI_PROVIDERS\", \"NOTIFICATIONS\", \"TALK\", \"TALK_BOT\", \"USER_INFO\", \"SYSTEM\", \"TEXT_PROCESSING\"],\"system\":1}" \
   --force-scopes --wait-finish

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ How To Install
 	*Example assuming you are in the source directory of your nextcloud instance where occ is located and the default user www-data got execution rights on occ*
 
 	> sudo -u www-data php ./occ app_api:app:unregister summarai
-	> sudo -u www-data php ./occ app_api:app:register summarai manual_install --json-info "{\"appid\":\"summarai\",\"name\":\"SummarAI\",\"daemon_config_name\":\"manual_install\",\"version\":\"1.0.0\",\"secret\":\"12345\",\"host\":\"192.168.0.199\",\"port\":9031, \"scopes\":[\"AI_PROVIDERS\", \"NOTIFICATIONS\", \"TALK\", \"TALK_BOT\", \"ALL\"],\"protocol\":\"http\",\"system_app\":1}" --force-scopes --wait-finish
+	> sudo -u www-data php ./occ app_api:app:register summarai manual_install --json-info "{\"id\":\"summarai\",\"name\":\"SummarAI\",\"daemon_config_name\":\"manual_install\",\"version\":\"1.0.0\",\"secret\":\"12345\",\"host\":\"192.168.0.199\",\"port\":9031, \"scopes\":[\"AI_PROVIDERS\", \"NOTIFICATIONS\", \"TALK\", \"TALK_BOT\", \"TEXT_PROCESSING\"],\"protocol\":\"http\",\"system\":1}" --force-scopes --wait-finish
 
 	**OR**
 

--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -32,7 +32,8 @@ This ensures that users can quickly grasp the essence of discussions without rea
 			<value>TALK_BOT</value>
 			<value>AI_PROVIDERS</value>
 			<value>NOTIFICATIONS</value>
+			<value>TEXT_PROCESSING</value>
 		</scopes>
-		<system>false</system>
+		<system>true</system>
 	</external-app>
 </info>


### PR DESCRIPTION
1. `deploy` command was deprecated in AppAPI `2.1.0`
2. for dev registration AppAPI now accepts values in `--json-info` with the same key names as in `info.xml`:
    * `appid` -> `id`
    * `system_app` -> `system`
    
3. In AppAPI `2.3.1` we have added `TEXT_PROCESSING` API scope (but we did not test it, I hope you will)
4. Adjusted `info.xml` - there were old values and no `system` flag.
5. Fixed typos in `Makefile`


